### PR TITLE
GitHub actions CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,22 @@
+name: build
+
+on: pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: node:14
+
+    steps:
+      - uses: actions/checkout@v2-beta
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+          registry-url: https://registry.npmjs.org/
+          cache: yarn
+      - name: Install dependencies
+        run: yarn
+      - name: Run build
+        run: yarn build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,22 @@
+name: lint
+
+on: pull_request
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    container: node:14
+
+    steps:
+      - uses: actions/checkout@v2-beta
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+          registry-url: https://registry.npmjs.org/
+          cache: yarn
+      - name: Install dependencies
+        run: yarn
+      - name: Run linter
+        run: yarn lint


### PR DESCRIPTION
This PR prevents pull requests that fail to run the `npm run build` script or have `npm run lint` errors. It does not block merges for lint warnings, but it does flag them in the code review. 