### PR TITLE
Calendar CSS Clean-up

### DIFF
--- a/src/components/calendar/CalendarView.jsx
+++ b/src/components/calendar/CalendarView.jsx
@@ -42,7 +42,7 @@ const CalendarView = () => {
   }, [currentStartDate]);
 
   return (
-    <div>
+    <div className='calendar-container'>
       <Calendar
         onClickDay={setDate}
         value={date}

--- a/src/components/calendar/test_search/FakeSearchSection.jsx
+++ b/src/components/calendar/test_search/FakeSearchSection.jsx
@@ -1,10 +1,12 @@
 import React, { useState } from 'react';
-import { FaSearch, FaMapMarkerAlt } from 'react-icons/fa';
+import { FaSearch, FaMapMarkerAlt, FaRegCalendar } from 'react-icons/fa';
+import DatePicker from 'react-datepicker';
 import AutoComplete from '../../search/Autocomplete';
+import 'react-datepicker/dist/react-datepicker.css';
 import styles from '../../../styles/Search.module.css';
 
 const FakeSearchSection = () => {
-  const dummyTags = ['Starting soon', 'Tomorrow', 'Near you', 'Dancers", Clowns', 'Magicians'];
+  const dummyTags = ['Starting soon', 'Tomorrow', 'Near you', 'Dancers', 'Clowns', 'Magicians'];
   const [searchTerm, setSearchTerm] = useState('');
   const [searchLocation, setSearchLocation] = useState('');
   const [searchDate, setSearchDate] = useState('');
@@ -15,10 +17,10 @@ const FakeSearchSection = () => {
   const onSearchLocationChange = (e) => {
     setSearchLocation(e.target.value);
   };
-  const onDateChange = (date, dateString) => {
+  const onDateChange = (date) => {
     if (date !== null) {
-      // console.log(date._d, dateString);
-      setSearchDate(dateString);
+      console.log(date);
+      setSearchDate(date);
     }
   };
   const onSearchSubmit = () => {
@@ -43,11 +45,11 @@ const FakeSearchSection = () => {
 
   return (
     <div id={styles.searchContainer}>
-      <h1>Find Your Next Performer:</h1>
+      <label id={styles.title}>Find Your Next Performer:</label>
 
       <div id={styles.searchForm}>
         <div className={styles.searchBar} id={styles.upperSearchBar}>
-        <AutoComplete className={styles.searchInput} suggestions={['aa', 'abc', 'abbba', 'asdaa', 'asddaa', 'ddsdef', 'iasdasgh']} />
+          <AutoComplete className={styles.searchInput} suggestions={dummyTags} />
           {/* <input className={styles.searchInput}
             onChange={onSearchTermChange}
             placeholder="Search by event name"
@@ -58,17 +60,21 @@ const FakeSearchSection = () => {
         <div className={styles.searchBar}>
           <input className={styles.searchInput}
             onChange={onSearchLocationChange}
-            placeholder="Search by location"
+            placeholder="Location"
           />
           <button className={styles.insideBtn}><FaMapMarkerAlt /></button>
         </div>
-        {/* <br/>
-        <Input.Search allowClear style={{ width: '95%' }} placeholder="Search by event name" />
-        <Input.Search allowClear style={{ width: '95%' }} placeholder="search by location" /> */}
+        {/* <label>
+          <DatePicker
+            customInput={<FaRegCalendar />}/>
+          <button id={styles.dateIcon}><FaRegCalendar /></button>
+        </label> */}
+        <div id={styles.datePicker}>
 
-        <div id={styles.datePicker}></div>
-
-        <button id={styles.searchBtn} onClick={onSearchSubmit}>Search</button>
+          <DatePicker wrapperClassName={styles.datePicker} selected={searchDate}
+            onChange={onDateChange}
+            placeholderText= 'Select Date Here'></DatePicker></div>
+        <button id={styles.searchBtn} className="master-button" onClick={onSearchSubmit}>Search</button>
       </div>
       <div id={styles.tagContainer}>
         {dummyTags.map((tag, index) => {

--- a/src/styles/Calendar.css
+++ b/src/styles/Calendar.css
@@ -21,7 +21,7 @@
   align-items: center;
 }
 .react-calendar {
-  width: 295px;
+  width: 290px;
   height: auto;
   margin: auto;
   padding: 15px;

--- a/src/styles/Calendar.css
+++ b/src/styles/Calendar.css
@@ -15,12 +15,13 @@
 
 .react-calendar {
   width: 350px;
-  max-width: 100%;
+  max-width: 95%;
+  max-height: 95%;
+  margin: auto;
+  line-height: 1.125em;
   background:var(--buskr-white);
   border: 1px solid var(--light-gray);
   border-radius: 8px;
-  line-height: 1.125em;
-  padding: 15px;
 }
 .react-calendar--doubleView {
   width: 700px;
@@ -45,7 +46,7 @@
 }
 .react-calendar button {
   margin: 0;
-  border: none;
+  border: 1px solid red;
   outline: none;
 }
 .react-calendar button:enabled:hover {
@@ -59,7 +60,7 @@
   background: none;
 }
 .react-calendar__navigation button {
-  min-width: 50px;
+  min-width: 40px;
   background: none;
   color: var(--buskr-purple);
   font-weight: 500;
@@ -103,25 +104,30 @@
   /* padding: calc(0.75em / 0.5) calc(0.75em / 0.5); */
 }
 /* individual day tile */
-.react-calendar__month-view__days__day {
+.react-calendar__month-view__days__day button {
+  padding: 0px;
+  margin: 0px;
+  width: 10px;
+  height: 10px;
+}
+.react-calendar__month-view__days__day button {
   padding: 0px;
 }
 /* weekend tile*/
 .react-calendar__month-view__days__day--weekend {
   /* color: #d10000; */
-  height: 3.25em;
 }
 .react-calendar__year-view .react-calendar__tile,
 .react-calendar__decade-view .react-calendar__tile,
 .react-calendar__century-view .react-calendar__tile {
-  padding: 2em 0.5em;
+  padding: 0px;
 }
 /* controls css for tiles and its contents (interior only, cant do border) */
 .react-calendar__tile {
   position: relative;
   max-width: 100%;
   text-align: center;
-  padding: 0.75em 0.5em;
+  padding: 0.5em 0.5em;
   color: var(--buskr-purple);
   background: none;
 }

--- a/src/styles/Calendar.css
+++ b/src/styles/Calendar.css
@@ -1,26 +1,30 @@
 /*/// Grabbed from globals.css ///*/
 
 :root {
-  --buskr-gray: #777777;
+  --buskr-lightgray: #D9D9D9;
+  --buskr-gray: #A1A1A9;
   --buskr-orange: #ff9767;
   --buskr-purple: #5f4c4c;
   --buskr-yellow: #ffd66c;
   --buskr-pink: #ff7585;
   --buskr-white: white;
-  --light-gray: #D9D9D9;
-  --dark-gray: #A1A1A9;
 } 
 
 /*/// Grabbed from globals.css ///*/
 
-.react-calendar {
-  width: 350px;
-  max-width: 95%;
-  max-height: 95%;
+.calendar-container {
+  padding-top: 18px;
   margin: auto;
+}
+
+.react-calendar {
+  width: 300px;
+  margin: auto;
+  padding: 15px;
+  padding-top: 5px;
   line-height: 1.125em;
   background:var(--buskr-white);
-  border: 1px solid var(--light-gray);
+  border: 1px solid var(--buskr-lightgray);
   border-radius: 8px;
 }
 .react-calendar--doubleView {
@@ -46,7 +50,7 @@
 }
 .react-calendar button {
   margin: 0;
-  border: 1px solid red;
+  border: none;
   outline: none;
 }
 .react-calendar button:enabled:hover {
@@ -55,12 +59,13 @@
 .react-calendar__navigation {
   display: flex;
   margin: auto;
-  height: 50px;
+  padding-top: 10px;
+  height: 40px;
   text-align: center;
   background: none;
 }
 .react-calendar__navigation button {
-  min-width: 40px;
+  min-width: 50px;
   background: none;
   color: var(--buskr-purple);
   font-weight: 500;
@@ -74,13 +79,13 @@
   background-color: none;
 }
 .react-calendar__navigation button[disabled] {
-  background-color: var(--light-gray);
+  background-color: var(--buskr-lightgray);
 }
 .react-calendar__month-view__weekdays {
   text-align: center;
   text-transform: uppercase;
   font-weight: 300;
-  color: var(--dark-gray);
+  color: var(--buskr-gray);
   font-size: 0.65em;
 }
 .react-calendar__month-view__weekdays__weekday {
@@ -100,18 +105,13 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 0.7em;
-  /* padding: calc(0.75em / 0.5) calc(0.75em / 0.5); */
 }
 /* individual day tile */
 .react-calendar__month-view__days__day button {
-  padding: 0px;
-  margin: 0px;
-  width: 10px;
-  height: 10px;
+  padding: 10px;
 }
-.react-calendar__month-view__days__day button {
-  padding: 0px;
+.react-calendar__month-view__days__day abbr {
+  /* padding: 0px; */
 }
 /* weekend tile*/
 .react-calendar__month-view__days__day--weekend {
@@ -127,7 +127,7 @@
   position: relative;
   max-width: 100%;
   text-align: center;
-  padding: 0.5em 0.5em;
+  padding: .85em;
   color: var(--buskr-purple);
   background: none;
 }
@@ -138,15 +138,16 @@
   height: 6px;
   border-radius: 50%;
   background-color: var(--buskr-pink);
-  top: 8px;
-  right: 8px;
+  top: 5px;
+  right: 5px;
 }
 /* days the belong to the previous/next month */
 .react-calendar__month-view__days__day--neighboringMonth {
-  color: var(--dark-gray);
+  color: var(--buskr-gray);
 }
+
 .react-calendar__tile:disabled {
-  background-color: var(--light-gray);
+  background-color: var(--buskr-lightgray);
 }
 /* hover on tile */
 .react-calendar__tile:enabled:hover {
@@ -178,8 +179,8 @@
 /* currectly selected tile */
 .react-calendar__tile--active {
   background: var(--buskr-pink);
-  color:var(--buskr-white);
   border-radius: 50%;
+  color:var(--buskr-white);
 }
 .react-calendar__tile--active:enabled:hover,
 .react-calendar__tile--active:enabled:focus {

--- a/src/styles/Calendar.css
+++ b/src/styles/Calendar.css
@@ -12,17 +12,14 @@
 
 /*/// Grabbed from globals.css ///*/
 
+/*//////// - Calendar - ////////*/
+
 .calendar-container {
   display: flex;
   height: 328px;
   justify-content: center;
   align-items: center;
 }
-
-.react-calendar__navigation__label__labelText {
-  pointer-events: none;
-}
-
 .react-calendar {
   width: 295px;
   height: auto;
@@ -33,17 +30,6 @@
   background:var(--buskr-white);
   border: 1px solid var(--buskr-lightgray);
   border-radius: 8px;
-}
-.react-calendar--doubleView {
-  width: 700px;
-}
-.react-calendar--doubleView .react-calendar__viewContainer {
-  display: flex;
-  margin: -0.5em;
-}
-.react-calendar--doubleView .react-calendar__viewContainer > * {
-  width: 50%;
-  margin: 0.5em;
 }
 .react-calendar,
 .react-calendar *,
@@ -63,6 +49,9 @@
 .react-calendar button:enabled:hover {
   cursor: pointer;
 }
+
+/*//////// - Navigation - ////////*/
+
 .react-calendar__navigation {
   display: flex;
   margin: auto;
@@ -78,16 +67,12 @@
   font-weight: 500;
   font-size: .9em;
 }
-.react-calendar__navigation button:enabled:hover {
-  /* color: var(--buskr-pink); */
-  background-color: none;
-}
-.react-calendar__navigation button:enabled:focus {
-  background-color: none;
-}
 .react-calendar__navigation button[disabled] {
   background-color: var(--buskr-lightgray);
 }
+
+/*//////// - Weekdays - ////////*/
+
 .react-calendar__month-view__weekdays {
   text-align: center;
   text-transform: uppercase;
@@ -102,10 +87,7 @@
   text-decoration: none;
 }
 
-/* individual day tile */
-.react-calendar__month-view__days__day button {
-  padding: 10px;
-}
+/*//////// - Day Tiles - ////////*/
 
 .react-calendar__tile {
   position: relative;
@@ -115,29 +97,25 @@
   color: var(--buskr-purple);
   background: none;
 }
-
-.react-calendar__tile:disabled {
-  background-color: var(--buskr-lightgray);
-}
-/* hover on tile */
+/* This order fixes the glitch-like bug */
 .react-calendar__tile:enabled:hover {
   color: var(--buskr-pink);
 }
-
-/* selected date */
 .react-calendar__tile:enabled:focus {
   color: var(--buskr-white);
 }
-
 .react-calendar__tile:enabled:active {
   color: var(--buskr-pink);
 }
-
 .react-calendar__tile--hasActive {
   background: var(--buskr-pink);
 }
+.react-calendar__tile:disabled {
+  background-color: var(--buskr-lightgray);
+}
 
 /*//////// - Currently Selected Tile - ////////*/
+
 .react-calendar__tile--active, .react-calendar__tile--hasActive {
   background: var(--buskr-pink);
   border-radius: 50%;
@@ -145,6 +123,7 @@
 }
 
 /*//////// - Calendar Label View - ////////*/
+
 .react-calendar__year-view__months__month, 
 .react-calendar__decade-view__years__year, 
 .react-calendar__century-view__decades__decade,

--- a/src/styles/Calendar.css
+++ b/src/styles/Calendar.css
@@ -68,7 +68,7 @@
   font-size: .9em;
 }
 .react-calendar__navigation button[disabled] {
-  background-color: var(--buskr-lightgray);
+  color: var(--buskr-gray);
 }
 
 /*//////// - Weekdays - ////////*/

--- a/src/styles/Calendar.css
+++ b/src/styles/Calendar.css
@@ -13,12 +13,19 @@
 /*/// Grabbed from globals.css ///*/
 
 .calendar-container {
-  padding-top: 18px;
-  margin: auto;
+  display: flex;
+  height: 328px;
+  justify-content: center;
+  align-items: center;
+}
+
+.react-calendar__navigation__label__labelText {
+  pointer-events: none;
 }
 
 .react-calendar {
-  width: 300px;
+  width: 295px;
+  height: auto;
   margin: auto;
   padding: 15px;
   padding-top: 5px;
@@ -69,7 +76,7 @@
   background: none;
   color: var(--buskr-purple);
   font-weight: 500;
-  font-size: 1em;
+  font-size: .9em;
 }
 .react-calendar__navigation button:enabled:hover {
   /* color: var(--buskr-pink); */
@@ -89,61 +96,24 @@
   font-size: 0.65em;
 }
 .react-calendar__month-view__weekdays__weekday {
-  padding: 0.5em;
+  padding: 0.2em;
 }
 .react-calendar__month-view__weekdays__weekday abbr {
   text-decoration: none;
 }
-.react-calendar__month-view__weekNumbers {
-  font-weight: 300;
-  text-decoration: none;
-}
-.react-calendar__month-view__weekNumbers {
-  font-weight: 300;
-}
-.react-calendar__month-view__weekNumbers .react-calendar__tile {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
+
 /* individual day tile */
 .react-calendar__month-view__days__day button {
   padding: 10px;
 }
-.react-calendar__month-view__days__day abbr {
-  /* padding: 0px; */
-}
-/* weekend tile*/
-.react-calendar__month-view__days__day--weekend {
-  /* color: #d10000; */
-}
-.react-calendar__year-view .react-calendar__tile,
-.react-calendar__decade-view .react-calendar__tile,
-.react-calendar__century-view .react-calendar__tile {
-  padding: 0px;
-}
-/* controls css for tiles and its contents (interior only, cant do border) */
+
 .react-calendar__tile {
   position: relative;
   max-width: 100%;
   text-align: center;
-  padding: .85em;
+  padding: .8em;
   color: var(--buskr-purple);
   background: none;
-}
-/*div for the indicator*/
-.notification {
-  position: absolute;
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background-color: var(--buskr-pink);
-  top: 5px;
-  right: 5px;
-}
-/* days the belong to the previous/next month */
-.react-calendar__month-view__days__day--neighboringMonth {
-  color: var(--buskr-gray);
 }
 
 .react-calendar__tile:disabled {
@@ -153,39 +123,46 @@
 .react-calendar__tile:enabled:hover {
   color: var(--buskr-pink);
 }
+
 /* selected date */
 .react-calendar__tile:enabled:focus {
   color: var(--buskr-white);
 }
+
 .react-calendar__tile:enabled:active {
   color: var(--buskr-pink);
 }
-/* today's tile */
-.react-calendar__tile--now {
-  /* background: var(--buskr-pink); */
-}
-/* hovering over tile */
-.react-calendar__tile--now:enabled:hover,
-.react-calendar__tile--now:enabled:focus {
-  /* background: #ffffa9; */
-}
+
 .react-calendar__tile--hasActive {
   background: var(--buskr-pink);
 }
-.react-calendar__tile--hasActive:enabled:hover,
-.react-calendar__tile--hasActive:enabled:focus {
-  /* background: #a9d4ff; */
-}
-/* currectly selected tile */
-.react-calendar__tile--active {
+
+/*//////// - Currently Selected Tile - ////////*/
+.react-calendar__tile--active, .react-calendar__tile--hasActive {
   background: var(--buskr-pink);
   border-radius: 50%;
   color:var(--buskr-white);
 }
-.react-calendar__tile--active:enabled:hover,
-.react-calendar__tile--active:enabled:focus {
-  /* background: #1087ff; */
+
+/*//////// - Calendar Label View - ////////*/
+.react-calendar__year-view__months__month, 
+.react-calendar__decade-view__years__year, 
+.react-calendar__century-view__decades__decade,
+.react-calendar__century-view .react-calendar__tile {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 3em;
+  border-radius: 8px;
 }
-.react-calendar--selectRange .react-calendar__tile--hover {
-  /* background-color: #e6e6e6; */
+
+/*//////// - Event Indicator - ////////*/
+.notification {
+  position: absolute;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background-color: var(--buskr-pink);
+  top: 5px;
+  right: 5px;
 }

--- a/src/styles/resultList.module.css
+++ b/src/styles/resultList.module.css
@@ -41,8 +41,9 @@
   border: var(--buskr-lightgray) solid 1px;
   border-top: none;
   height: 330px;
-  border-radius: 0px 0px 8px 8px;
   overflow: auto;
+  border-bottom-left-radius: 5px;
+  border-bottom-right-radius: 5px;
 }
 
 .eventItemContainer {

--- a/src/styles/resultList.module.css
+++ b/src/styles/resultList.module.css
@@ -43,8 +43,6 @@
   height: 330px;
   border-radius: 0px 0px 8px 8px;
   overflow: auto;
-  border-bottom-left-radius: 5px;
-  border-bottom-right-radius: 5px;
 }
 
 .eventItemContainer {

--- a/src/styles/resultList.module.css
+++ b/src/styles/resultList.module.css
@@ -1,5 +1,5 @@
 .tabsContainer {
-  margin-top: 2em;
+  margin-top: 1em;
 }
 
 .roundedTabs {
@@ -21,6 +21,10 @@
   font-size: 15px;
 }
 
+.tabs button {
+  padding-top: 5px;
+}
+
 .activeTabs {
   color: white;
   background-color: var(--buskr-pink);
@@ -36,7 +40,8 @@
 .tabsContent {
   border: var(--buskr-lightgray) solid 1px;
   border-top: none;
-  max-height: 300px;
+  height: 320px;
+  border-radius: 0px 0px 8px 8px;
   overflow: auto;
 }
 

--- a/src/styles/resultList.module.css
+++ b/src/styles/resultList.module.css
@@ -40,7 +40,7 @@
 .tabsContent {
   border: var(--buskr-lightgray) solid 1px;
   border-top: none;
-  height: 320px;
+  height: 330px;
   border-radius: 0px 0px 8px 8px;
   overflow: auto;
 }


### PR DESCRIPTION
## What this PR does?
### Calendar.css
- Fixed the oval --> Now it's a circle at last! :D
- Re-sized margin and font to fit the tab container 
- Added consistent styling to the "monthly", "yearly", "century", and "decade" views (see gif for demo)
- Created a `calendar-container` className to wrap around calendar and add flexbox to it so now it will auto-center itself calendar height change.

### resultList.module.css (Search Team's css - already consulted change with Eunji)
- Noticed some weeks have 6 week rows (see gif for demo), so re-adjusted "tab container" height to 330px to fit calendar.

### Before 

![Screen Shot 2021-12-11 at 1 32 08 PM](https://user-images.githubusercontent.com/39775868/145768994-80c1d780-b9d8-4e60-8f8e-3be34b158364.png)
> Added red border for visualization purposes
### After
![calendar-updated-css](https://user-images.githubusercontent.com/39775868/145769086-867e24cc-8b94-416a-ba1d-43dbfb3e47e9.gif)
> Update: Changed the disabled navigation button to change font color to buskr-gray instead of the background. (gif - last part where "decade" view (2001-2100) had a gray background, now it's just the the font gets grayed out)

### Related Team
Modified Search Team's `resultList.module.css` (already consulted with Eunji)

## Mentions

@jonathanjewett - pair partner
@c4mino @roheunji - Code Review

Thanks!
