### PR TITLE
Map refactoring

### DIFF
--- a/src/components/map/Map.jsx
+++ b/src/components/map/Map.jsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { GoogleMap, useJsApiLoader } from '@react-google-maps/api';
-import Image from 'next/image';
 import styles from '../../styles/map.module.css';
 
 const InfoBox = function InfoBox(props) {
@@ -12,13 +11,51 @@ const InfoBox = function InfoBox(props) {
   const description = feature.getProperty('description');
   return (
     <article className={styles.infobox}>
-          <img className={styles.infoPhoto} src={photos[0]} />
+          <img className={styles.infoPhoto} src={photos[0]} alt={name}/>
           <div className={styles.infoDetails}>
             <div className={styles.infoBoxName}>{name}</div>
             <div className={styles.infoBoxBuskerName}>{buskerName}</div>
           </div>
     </article>
   );
+};
+
+const MapWithLessStuff = function MapWithLessStuff({ containerStyle, center }) {
+  const { isLoaded } = useJsApiLoader({
+    id: 'google-map-script',
+    googleMapsApiKey: process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY,
+    googleMapsClientId: process.env.NEXT_PUBLIC_GOOGLE_MAPS_CLIENT_ID,
+    version: 3,
+  });
+
+  // const [position, setPosition] = useState(center);
+  // const [visible, setVisible] = useState(false);
+
+  const onLoad = React.useCallback((/** @type {google.maps.Map} */ map) => {
+    // const pin = new google.maps.Marker({
+    //   position: center,
+    //   map,
+    //   draggable: true,
+    // }).setMap(map);
+
+    // map.addListener('drag', () => {
+    //   console.log(pin.getPosition());
+    // });
+  }, []);
+
+  // style={{ width: '100vw', height: '100vh' }}>
+  return isLoaded ? (
+    <div className={styles.mapContainer}>
+      <GoogleMap
+        mapContainerStyle={containerStyle}
+        center={center}
+        zoom={17}
+        onLoad={onLoad}
+        options={{ mapId: 'c4f800a3ac3629c2' }}
+      >
+      </GoogleMap>
+    </div>
+  ) : null;
 };
 
 const Map = function Map({ containerStyle, center, withInfoBoxes }) {
@@ -74,3 +111,4 @@ const Map = function Map({ containerStyle, center, withInfoBoxes }) {
 };
 
 export default React.memo(Map);
+export { MapWithLessStuff };

--- a/src/components/map/Map.jsx
+++ b/src/components/map/Map.jsx
@@ -24,6 +24,7 @@ const InfoBox = function InfoBox(props) {
 * @param {Object} props
 * @param {React.CSSProperties} props.containerStyle
 * @param {google.maps.LatLngLiteral} props.center
+* @param {'view' | 'create'} props.mode
 * @param {(google.maps.LatLngLiteral) => void=} props.onDrop
 */
 const Map = function Map({ containerStyle, center, mode, onDrop }) {
@@ -70,7 +71,7 @@ const Map = function Map({ containerStyle, center, mode, onDrop }) {
     if (mode === 'view') {
       map.data.loadGeoJson('/sample_events.json', { idPropertyName: 'storeid' });
     }
-  }, [center, mode]);
+  }, [center, mode, onDrop]);
 
   // style={{ width: '100vw', height: '100vh' }}>
   return isLoaded ? (

--- a/src/components/map/Map.jsx
+++ b/src/components/map/Map.jsx
@@ -28,19 +28,16 @@ const MapWithLessStuff = function MapWithLessStuff({ containerStyle, center }) {
     version: 3,
   });
 
-  // const [position, setPosition] = useState(center);
-  // const [visible, setVisible] = useState(false);
-
   const onLoad = React.useCallback((/** @type {google.maps.Map} */ map) => {
-    // const pin = new google.maps.Marker({
-    //   position: center,
-    //   map,
-    //   draggable: true,
-    // }).setMap(map);
+    const pin = new google.maps.Marker({
+      position: center,
+      map,
+      draggable: true,
+    }).setMap(map);
 
-    // map.addListener('drag', () => {
-    //   console.log(pin.getPosition());
-    // });
+    pin.addListener('drag', (mapsMouseEvent) => {
+      console.log('Drag me');
+    });
   }, []);
 
   // style={{ width: '100vw', height: '100vh' }}>

--- a/src/components/map/Map.jsx
+++ b/src/components/map/Map.jsx
@@ -20,21 +20,20 @@ const InfoBox = function InfoBox(props) {
   );
 };
 
-let currentMarker = null;
 /**
 * @param {Object} props
-* @param {'view' | 'create'} props.mode
+* @param {React.CSSProperties} props.containerStyle
+* @param {google.maps.LatLngLiteral} props.center
+* @param {(google.maps.LatLngLiteral) => void=} props.onDrop
 */
-const Map = function Map({ containerStyle, center, mode, withInfoBoxes }) {
+const Map = function Map({ containerStyle, center, mode, onDrop }) {
   const { isLoaded } = useJsApiLoader({
     id: 'google-map-script',
-    googleMapsApiKey: process.env.NEXT_PUBLIC_GOOGLE_KEY,
-    googleMapsClientId: process.env.NEXT_PUBLIC_GOOGLE_CLIENT,
+    googleMapsApiKey: process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY,
+    googleMapsClientId: process.env.NEXT_PUBLIC_GOOGLE_MAPS_CLIENT_ID,
     version: 3,
   });
-
   const [infoFeature, setInfoFeature] = useState(null);
-
   const onLoad = React.useCallback((/** @type {google.maps.Map} */ map) => {
     /* eslint-disable-next-line no-new */
     new google.maps.Marker({
@@ -52,15 +51,17 @@ const Map = function Map({ containerStyle, center, mode, withInfoBoxes }) {
 
       const center = { lat: lat(), lng: lng() };
 
-      if (currentMarker === null) {
-        currentMarker = new google.maps.Marker({
+      if (map.currentMarker) {
+        map.currentMarker = new google.maps.Marker({
           position: center,
           map,
           draggable: true,
         });
       } else {
-        currentMarker.setPosition(center);
+        map.currentMarker.setPosition(center);
       }
+
+      onDrop(center);
     });
 
     map.data.addListener('click', ({ feature }) => {
@@ -81,7 +82,7 @@ const Map = function Map({ containerStyle, center, mode, withInfoBoxes }) {
     onLoad={onLoad}
     options={{ mapId: 'c4f800a3ac3629c2' }}
     >
-    {withInfoBoxes && infoFeature && <InfoBox feature={infoFeature} />}
+    {mode === 'view' && infoFeature && <InfoBox feature={infoFeature} />}
     </GoogleMap>
     </div>
   ) : null;


### PR DESCRIPTION
<img width="279" alt="Screen Shot 2021-12-13 at 11 04 20 AM" src="https://user-images.githubusercontent.com/4971311/145872525-3cea0169-6ce4-4dd0-b855-1aef14d1d2db.png">

This update to the Map creates 2 modes for the component,  'view' and 'create'.  If you pass a callback to the optional `onDrop` property, the map will render in Create Mode, otherwise it will render in View Mode.

- View Mode: loads and displays event markers. No other interactivity.
- Create mode: Provides a click event listener that drops a pin on the map, and passes the latitude and longitude of the current pin position to a callback from the prop `onDrop`.
  - Clicking once will place a pin, clicking again in a different spot will change the position of the pin.
  - Currently does not display existing events.

We removed the prop `withInfoBoxes` because this is now handled by View Mode.
We added a dot that marks "You are Here"