### PR TITLE
Fix broken dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   },
   "dependencies": {
     "@aws-sdk/client-cognito-identity": "^3.43.0",
-    "@aws-sdk/client-s3": "^3.44.0",
     "@react-google-maps/api": "^2.7.0",
     "axios": "^0.21.0",
     "express": "^4.15.0",
@@ -25,7 +24,6 @@
     "react-datepicker": "^4.5.0",
     "react-dom": "17.0.2",
     "react-icons": "^4.3.1",
-    "react-images-upload": "^1.2.8",
     "redis": "^4.0.0"
   },
   "devDependencies": {
@@ -37,5 +35,8 @@
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-next": "^12.0.7",
     "faker": "^5.5.3"
+  },
+  "optionalDependencies": {
+    "@aws-sdk/client-s3": "^3.44.0",
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "faker": "^5.5.3"
   },
   "optionalDependencies": {
-    "@aws-sdk/client-s3": "^3.44.0",
+    "@aws-sdk/client-s3": "^3.44.0"
   }
 }


### PR DESCRIPTION
- Removed [react-image-upload](https://www.npmjs.com/package/react-images-upload) because it uses an outdated version of React
- Moved [@aws-sdk/client-s3](https://www.npmjs.com/package/@aws-sdk/client-s3) to optionalDependencies because it requires on CMake