### PR TITLE
Add Image to Event

### DIFF
--- a/src/components/create-event/CreateEvent.jsx
+++ b/src/components/create-event/CreateEvent.jsx
@@ -58,6 +58,9 @@ const CreateEvent3 = ({
   handleUploadMode,
   uploadMode,
   image,
+  submitAttempted,
+  name,
+  description,
 }) => {
   const [uploadView, setUploadView] = useState(false);
   useEffect(() => {
@@ -71,10 +74,16 @@ const CreateEvent3 = ({
           <div className='master-title'>Create Event</div>
           <form className={styles.formContainer}>
             <div className={styles.smallTitle}> Event Name: </div>
-            <div className={styles.validationWarning}> Please enter an event name </div>
+            <div className={submitAttempted && !name
+              ? styles.validationWarning
+              : styles.validationWarningHidden}>
+                Please enter an event name
+              </div>
               <input onChange={handleName} type='search' className={styles.masterSearchBar} placeholder='Enter Event Name'></input>
             <div className={styles.smallTitle}> Description: </div>
-            <div className={styles.validationWarning}> Please enter a description </div>
+            <div className={submitAttempted && !description
+              ? styles.validationWarning
+              : styles.validationWarningHidden}> Please enter a description </div>
               <textarea onChange={handleDescription} type='search' className={styles.descriptionField}placeholder='Enter Description'></textarea>
             <div className={styles.tagsDescription}>
               <div className={styles.smallTitle}> Tags </div>
@@ -118,6 +127,7 @@ const CreateEvent = ({ center }) => {
   const [loc, setEventLoc] = useState();
   const [tags, setEventTags] = useState();
   const [uploadMode, setUploadMode] = useState(false);
+  const [submitAttempted, setSubmitAttempted] = useState(false);
 
   useEffect(() => {
     setEventLoc(center);
@@ -163,6 +173,7 @@ const CreateEvent = ({ center }) => {
 
   const handleAddMyEvent = () => {
     console.log('ADD MY EVENT CLICKED!');
+    setSubmitAttempted(true);
   };
 
   const handleImage = (img) => {
@@ -203,6 +214,9 @@ const CreateEvent = ({ center }) => {
         handleUploadMode={handleUploadMode}
         uploadMode={uploadMode}
         image={image}
+        submitAttempted={submitAttempted}
+        name={name}
+        description={description}
       />
     );
   }

--- a/src/components/create-event/CreateEvent.jsx
+++ b/src/components/create-event/CreateEvent.jsx
@@ -57,6 +57,7 @@ const CreateEvent3 = ({
   handleAddMyEvent,
   handleUploadMode,
   uploadMode,
+  image,
 }) => {
   const [uploadView, setUploadView] = useState(false);
   useEffect(() => {
@@ -82,7 +83,11 @@ const CreateEvent3 = ({
               <input onChange={handleTags} type='search' className={styles.masterSearchBar}placeholder='Add Tags (separated by comma)'></input>
           </form>
           {/* if image exists, render image, otherwise render button */}
-          <button onClick={handleUploadMode} type='text' className={styles.uploadImageButton}>Upload Image</button>
+          {image
+            ? <img className={styles.uploadedImage} src={image} alt=''/>
+            : <button onClick={handleUploadMode} type='text' className={styles.uploadImageButton}>Upload Image</button>
+          }
+
         </div>
         <button onClick={handleAddMyEvent} type='text' className='master-button'> Add My Event </button>
       </div>
@@ -197,6 +202,7 @@ const CreateEvent = ({ center }) => {
         handleAddMyEvent={handleAddMyEvent}
         handleUploadMode={handleUploadMode}
         uploadMode={uploadMode}
+        image={image}
       />
     );
   }

--- a/src/components/create-event/CreateEvent.jsx
+++ b/src/components/create-event/CreateEvent.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import ImageUploader from './UploadImage';
 import styles from '../../styles/CreateEvent.module.css';
 import Map from '../map/Map';
 
@@ -49,29 +50,46 @@ const CreateEvent2 = () => (
 );
 
 const CreateEvent3 = ({
-  handleName, handleDescription, handleTags, handleImage, handleAddMyEvent,
-}) => (
-  <div className={styles.eventUploadContainer}>
-    <div className={styles.formAndButtonContainer}>
-      <div className='master-title'>Create Event</div>
-      <form className={styles.formContainer}>
-        <div className={styles.smallTitle}> Event Name: </div>
-        <div className={styles.validationWarning}> Please enter an event name </div>
-          <input onChange={handleName} type='search' className={styles.masterSearchBar} placeholder='Enter Event Name'></input>
-        <div className={styles.smallTitle}> Description: </div>
-        <div className={styles.validationWarning}> Please enter a description </div>
-          <textarea onChange={handleDescription} type='search' className={styles.descriptionField}placeholder='Enter Description'></textarea>
-        <div className={styles.tagsDescription}>
-          <div className={styles.smallTitle}> Tags </div>
-          <div className={styles.tagSubtext}> (OPTIONAL - Separated By Comma)  </div>
+  handleName,
+  handleDescription,
+  handleTags,
+  handleImage,
+  handleAddMyEvent,
+  handleUploadMode,
+  uploadMode,
+}) => {
+  const [uploadView, setUploadView] = useState(false);
+  useEffect(() => {
+    setUploadView(uploadMode);
+  }, [uploadMode]);
+
+  if (!uploadView) {
+    return (
+      <div className={styles.eventUploadContainer}>
+        <div className={styles.formAndButtonContainer}>
+          <div className='master-title'>Create Event</div>
+          <form className={styles.formContainer}>
+            <div className={styles.smallTitle}> Event Name: </div>
+            <div className={styles.validationWarning}> Please enter an event name </div>
+              <input onChange={handleName} type='search' className={styles.masterSearchBar} placeholder='Enter Event Name'></input>
+            <div className={styles.smallTitle}> Description: </div>
+            <div className={styles.validationWarning}> Please enter a description </div>
+              <textarea onChange={handleDescription} type='search' className={styles.descriptionField}placeholder='Enter Description'></textarea>
+            <div className={styles.tagsDescription}>
+              <div className={styles.smallTitle}> Tags </div>
+              <div className={styles.tagSubtext}> (OPTIONAL - Separated By Comma)  </div>
+            </div>
+              <input onChange={handleTags} type='search' className={styles.masterSearchBar}placeholder='Add Tags (separated by comma)'></input>
+          </form>
+          {/* if image exists, render image, otherwise render button */}
+          <button onClick={handleUploadMode} type='text' className={styles.uploadImageButton}>Upload Image</button>
         </div>
-          <input onChange={handleTags} type='search' className={styles.masterSearchBar}placeholder='Add Tags (separated by comma)'></input>
-      </form>
-      <button onClick={handleImage} type='text' className={styles.uploadImageButton}>Upload Image</button>
-    </div>
-    <button onClick={handleAddMyEvent} type='text' className='master-button'> Add My Event </button>
-  </div>
-);
+        <button onClick={handleAddMyEvent} type='text' className='master-button'> Add My Event </button>
+      </div>
+    );
+  }
+  return <ImageUploader handleImage={handleImage}/>;
+};
 
 // const dummyEventInfo = {
 //   name: '',
@@ -85,7 +103,7 @@ const CreateEvent3 = ({
 // }
 
 const CreateEvent = ({ center }) => {
-  const [createPage, setCreatePage] = useState(1);
+  const [createPage, setCreatePage] = useState(3);
   const [name, setEventName] = useState();
   const [description, setEventDescription] = useState();
   const [image, setEventImage] = useState();
@@ -94,6 +112,7 @@ const CreateEvent = ({ center }) => {
   const [end, setEventEnd] = useState();
   const [loc, setEventLoc] = useState();
   const [tags, setEventTags] = useState();
+  const [uploadMode, setUploadMode] = useState(false);
 
   useEffect(() => {
     setEventLoc(center);
@@ -141,8 +160,15 @@ const CreateEvent = ({ center }) => {
     console.log('ADD MY EVENT CLICKED!');
   };
 
-  const handleImage = () => {
+  const handleImage = (img) => {
     console.log('Upload Image button was clicked!');
+    setEventImage(img);
+    setUploadMode(false);
+  };
+
+  const handleUploadMode = () => {
+    console.log('switch upload view!');
+    setUploadMode(true);
   };
 
   if (createPage === 1) {
@@ -169,6 +195,8 @@ const CreateEvent = ({ center }) => {
         handleDescription={handleDescription}
         handleImage={handleImage}
         handleAddMyEvent={handleAddMyEvent}
+        handleUploadMode={handleUploadMode}
+        uploadMode={uploadMode}
       />
     );
   }

--- a/src/components/create-event/UploadImage.jsx
+++ b/src/components/create-event/UploadImage.jsx
@@ -30,47 +30,39 @@ const ImageUploader = ({ handleImage }) => {
           dragProps,
         }) => (
           // write your building UI
-          <div className={styles.uploadRemoveButtonsContainer}>
+          <div>
+          <div className={styles.dragAreaAndButtonsContainer}>
             {images.length === 0
-              ? <button
-                className={isDragging ? styles.dragging : styles.clickOrDrag}
-                onClick={onImageUpload}
-                {...dragProps}
-              >
-                Click or Drop here
-              </button>
-              : <button
-              className={styles.dragged}
-              onClick={onImageUpload}
-              {...dragProps}
-            >
-              <img className={styles.currentImage} src={images[images.length - 1].data_url} alt=''/>
-            </button>
+              ? <button className={isDragging ? styles.dragging : styles.clickOrDrag}
+                  onClick={onImageUpload}{...dragProps}>
+                  Click or Drop here
+                </button>
+              : <button className={styles.dragged} onClick={onImageUpload}{...dragProps}>
+                  <img className={styles.currentImage} src={images[images.length - 1].data_url} alt=''/>
+                </button>
             }
             &nbsp;
-            <div className={styles.addBackRemoveButtonsContainer}>
-              <button onClick={() => handleImage(images[images.length - 1].data_url)}className='master-button'>Add Image</button>
-              <div className={styles.skipAndRemoveButton}>
-                <button className={styles.skipThisStep}>Skip this step</button>
-                <button
-                  className={styles.removeAllImages}
-                  onClick={onImageRemoveAll}
-                >
-                    Remove Image
+            <div className={styles.backRemoveButtonsContainer}>
+                <button className={styles.skipThisStep}>Go Back</button>
+                <button className={styles.removeAllImages} onClick={onImageRemoveAll}>
+                  Remove Image
                 </button>
-              </div>
             </div>
             {/* GALLERY AT BOTTOM */}
             {/* {imageList.map((image, index) => (
               <div key={index} className="image-item">
-                <img src={image.data_url} alt="" width="100" />
-                <div className="image-item__btn-wrapper">
-                  <button onClick={() => onImageUpdate(index)}>Update</button>
-                  <button onClick={() => onImageRemove(index)}>Remove</button>
-                </div>
+              <img src={image.data_url} alt="" width="100" />
+              <div className="image-item__btn-wrapper">
+              <button onClick={() => onImageUpdate(index)}>Update</button>
+              <button onClick={() => onImageRemove(index)}>Remove</button>
+              </div>
               </div>
             ))} */}
           </div>
+        <button onClick={() => handleImage(images[images.length - 1].data_url)}className='master-button'>
+          Add Image
+        </button>
+        </div>
         )}
       </ImageUploading>
     </div>

--- a/src/components/create-event/UploadImage.jsx
+++ b/src/components/create-event/UploadImage.jsx
@@ -12,7 +12,7 @@ const ImageUploader = ({ handleImage }) => {
   };
 
   return (
-    <div className={styles.imageUploader}>
+    <div>
       <ImageUploading
         multiple
         value={images}
@@ -30,39 +30,39 @@ const ImageUploader = ({ handleImage }) => {
           dragProps,
         }) => (
           // write your building UI
-          <div>
-          <div className={styles.dragAreaAndButtonsContainer}>
-            {images.length === 0
-              ? <button className={isDragging ? styles.dragging : styles.clickOrDrag}
-                  onClick={onImageUpload}{...dragProps}>
-                  Click or Drop here
-                </button>
-              : <button className={styles.dragged} onClick={onImageUpload}{...dragProps}>
-                  <img className={styles.currentImage} src={images[images.length - 1].data_url} alt=''/>
-                </button>
-            }
-            &nbsp;
-            <div className={styles.backRemoveButtonsContainer}>
-                <button className={styles.skipThisStep}>Go Back</button>
-                <button className={styles.removeAllImages} onClick={onImageRemoveAll}>
-                  Remove Image
-                </button>
+          <div className={styles.uploadImageViewContainer}>
+            <div className={styles.dragAreaAndButtonsContainer}>
+              {images.length === 0
+                ? <button className={isDragging ? styles.dragging : styles.clickOrDrag}
+                    onClick={onImageUpload}{...dragProps}>
+                    Click or Drop here
+                  </button>
+                : <button className={styles.dragged} onClick={onImageUpload}{...dragProps}>
+                    <img className={styles.currentImage} src={images[images.length - 1].data_url} alt=''/>
+                  </button>
+              }
+              &nbsp;
+              <div className={styles.backRemoveButtonsContainer}>
+                  <button className={styles.skipThisStep}>Go Back</button>
+                  <button className={styles.removeAllImages} onClick={onImageRemoveAll}>
+                    Remove Image
+                  </button>
+              </div>
+              {/* GALLERY AT BOTTOM */}
+              {/* {imageList.map((image, index) => (
+                <div key={index} className="image-item">
+                <img src={image.data_url} alt="" width="100" />
+                <div className="image-item__btn-wrapper">
+                <button onClick={() => onImageUpdate(index)}>Update</button>
+                <button onClick={() => onImageRemove(index)}>Remove</button>
+                </div>
+                </div>
+              ))} */}
             </div>
-            {/* GALLERY AT BOTTOM */}
-            {/* {imageList.map((image, index) => (
-              <div key={index} className="image-item">
-              <img src={image.data_url} alt="" width="100" />
-              <div className="image-item__btn-wrapper">
-              <button onClick={() => onImageUpdate(index)}>Update</button>
-              <button onClick={() => onImageRemove(index)}>Remove</button>
-              </div>
-              </div>
-            ))} */}
+            <button onClick={() => handleImage(images[images.length - 1].data_url)}className='master-button'>
+              Add Image
+            </button>
           </div>
-        <button onClick={() => handleImage(images[images.length - 1].data_url)}className='master-button'>
-          Add Image
-        </button>
-        </div>
         )}
       </ImageUploading>
     </div>

--- a/src/components/create-event/UploadImage.jsx
+++ b/src/components/create-event/UploadImage.jsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import ImageUploading from 'react-images-uploading';
+import styles from '../../styles/ImageUploader.module.css';
+
+const ImageUploader = ({ handleImage }) => {
+  const [images, setImages] = React.useState([]);
+  const maxNumber = 10;
+  const onChange = (imageList, addUpdateIndex) => {
+    // data for submit
+    console.log(imageList, addUpdateIndex);
+    setImages(imageList);
+  };
+
+  return (
+    <div className={styles.imageUploader}>
+      <ImageUploading
+        multiple
+        value={images}
+        onChange={onChange}
+        maxNumber={maxNumber}
+        dataURLKey="data_url"
+      >
+        {({
+          imageList,
+          onImageUpload,
+          onImageRemoveAll,
+          onImageUpdate,
+          onImageRemove,
+          isDragging,
+          dragProps,
+        }) => (
+          // write your building UI
+          <div className={styles.uploadRemoveButtonsContainer}>
+            {images.length === 0
+              ? <button
+                className={isDragging ? styles.dragging : styles.clickOrDrag}
+                onClick={onImageUpload}
+                {...dragProps}
+              >
+                Click or Drop here
+              </button>
+              : <button
+              className={styles.dragged}
+              onClick={onImageUpload}
+              {...dragProps}
+            >
+              <img className={styles.currentImage} src={images[images.length - 1].data_url} alt=''/>
+            </button>
+            }
+            &nbsp;
+            <div className={styles.addBackRemoveButtonsContainer}>
+              <button onClick={() => handleImage(images[images.length - 1].data_url)}className='master-button'>Add Image</button>
+              <div className={styles.skipAndRemoveButton}>
+                <button className={styles.skipThisStep}>Skip this step</button>
+                <button
+                  className={styles.removeAllImages}
+                  onClick={onImageRemoveAll}
+                >
+                    Remove Image
+                </button>
+              </div>
+            </div>
+            {/* GALLERY AT BOTTOM */}
+            {/* {imageList.map((image, index) => (
+              <div key={index} className="image-item">
+                <img src={image.data_url} alt="" width="100" />
+                <div className="image-item__btn-wrapper">
+                  <button onClick={() => onImageUpdate(index)}>Update</button>
+                  <button onClick={() => onImageRemove(index)}>Remove</button>
+                </div>
+              </div>
+            ))} */}
+          </div>
+        )}
+      </ImageUploading>
+    </div>
+  );
+};
+
+export default ImageUploader;

--- a/src/styles/CreateEvent.module.css
+++ b/src/styles/CreateEvent.module.css
@@ -99,6 +99,7 @@
 }
 
 .uploadedImage {
+  margin-top: 25px;
   height: 200px;
   border-radius: 10px;
   width: 100%;
@@ -113,7 +114,12 @@
 
 .validationWarning {
   color: var(--buskr-pink);
-  /* visibility: hidden; */
+  height: 20px;
+}
+
+.validationWarningHidden {
+  height: 20px;
+  visibility: hidden;
 }
 
 .tagsDescription {

--- a/src/styles/CreateEvent.module.css
+++ b/src/styles/CreateEvent.module.css
@@ -81,7 +81,7 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  min-height: 100%;
+  /* min-height: 100%; */
   /* PLEASE MAKE THIS DYNAMIC THX */
   height: 715px;
 }

--- a/src/styles/CreateEvent.module.css
+++ b/src/styles/CreateEvent.module.css
@@ -98,6 +98,13 @@
   width: 150px;
 }
 
+.uploadedImage {
+  height: 200px;
+  border-radius: 10px;
+  width: 100%;
+  object-fit: cover;
+}
+
 .validationWarning, .smallTitle, .tagSubtext {
   font-size: 13px;
   margin-left: 5px;

--- a/src/styles/ImageUploader.module.css
+++ b/src/styles/ImageUploader.module.css
@@ -1,19 +1,29 @@
-/* .imageUploader {
+.imageUploader {
   padding: 0px 0px 0px 0px;
   margin: 0px 0px 0px 0px;
-} */
-
-.uploadRemoveButtonsContainer {
   display: flex;
   flex-direction: column;
   margin-top: 20px;
+  height: 715px;
+  justify-content: space-between;
+}
+
+.dragAreaAndButtonsContainer {
+  display: flex;
+  flex-direction: column;
+  margin-top: 20px;
+  width: 335px;
+  justify-content: flex-start;
 }
 
 
-.clickOrDrag, .dragging {
+.clickOrDrag, .dragging, .dragged {
+  display: flex;
+  justify-content: center;
+  align-items: center;
   border: 2px solid var(--buskr-pink);
   height: 400px;
-  width: 100%;
+  width: 335px;
   border-radius: 10px;
   padding: 0px 0px 0px 0px;
   margin: 0px 0px 0px 0px;
@@ -24,23 +34,27 @@
   color: var(--buskr-white);
 }
 
-.dragged {
+/* .dragged {
   border: none;
-}
+  height: 400px;
+  width: 335px;
+} */
 
 .currentImage {
   border: 2px solid var(--buskr-pink);
   border-radius: 10px;
   height: 400px;
   width: 335px;
-  width: 100%;
   object-fit: cover;
 }
 
 
-.addBackRemoveButtonsContainer {
+.backRemoveButtonsContainer {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  justify-content: space-between;
+  padding: 0px 0px 0px 0px;
+  margin: 0px 0px 0px 0px;
 }
 
 .skipAndRemoveButton {

--- a/src/styles/ImageUploader.module.css
+++ b/src/styles/ImageUploader.module.css
@@ -1,13 +1,3 @@
-/* .imageUploader {
-  padding: 0px 0px 0px 0px;
-  margin: 0px 0px 0px 0px;
-  display: flex;
-  flex-direction: column;
-  margin-top: 20px;
-  height: 715px;
-  justify-content: space-between;
-} */
-
 .uploadImageViewContainer {
   display: flex;
   flex-direction: column;
@@ -28,12 +18,16 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  border: 2px solid var(--buskr-pink);
+  border: 1px solid var(--buskr-pink);
   height: 400px;
   width: 335px;
   border-radius: 10px;
   padding: 0px 0px 0px 0px;
   margin: 0px 0px 0px 0px;
+}
+
+.clickOrDrag {
+  background-color: rgb(226, 226, 226);
 }
 
 .dragging {
@@ -48,7 +42,7 @@
 } */
 
 .currentImage {
-  border: 2px solid var(--buskr-pink);
+  /* border: 2px solid var(--buskr-pink); */
   border-radius: 10px;
   height: 400px;
   width: 335px;
@@ -74,7 +68,7 @@
   border: none;
   background-color: var(--buskr-purple);
   padding: 15px 15px 15px 15px;
-  margin: 20px 0px 20px 0px;
+  /* margin: 20px 0px 20px 0px; */
   border-radius: 10px;
   color: white;
   font-size: 17px;

--- a/src/styles/ImageUploader.module.css
+++ b/src/styles/ImageUploader.module.css
@@ -1,0 +1,66 @@
+/* .imageUploader {
+  padding: 0px 0px 0px 0px;
+  margin: 0px 0px 0px 0px;
+} */
+
+.uploadRemoveButtonsContainer {
+  display: flex;
+  flex-direction: column;
+  margin-top: 20px;
+}
+
+
+.clickOrDrag, .dragging {
+  border: 2px solid var(--buskr-pink);
+  height: 400px;
+  width: 100%;
+  border-radius: 10px;
+  padding: 0px 0px 0px 0px;
+  margin: 0px 0px 0px 0px;
+}
+
+.dragging {
+  background-color: var(--buskr-pink);
+  color: var(--buskr-white);
+}
+
+.dragged {
+  border: none;
+}
+
+.currentImage {
+  border: 2px solid var(--buskr-pink);
+  border-radius: 10px;
+  height: 400px;
+  width: 335px;
+  width: 100%;
+  object-fit: cover;
+}
+
+
+.addBackRemoveButtonsContainer {
+  display: flex;
+  flex-direction: column;
+}
+
+.skipAndRemoveButton {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}
+
+.removeAllImages, .skipThisStep {
+  border: none;
+  background-color: var(--buskr-purple);
+  padding: 15px 15px 15px 15px;
+  margin: 20px 0px 20px 0px;
+  border-radius: 10px;
+  color: white;
+  font-size: 17px;
+  font-weight: bold;
+  width: 158px;
+}
+
+.removeAllImages {
+  background-color: var(--buskr-purple)
+}

--- a/src/styles/ImageUploader.module.css
+++ b/src/styles/ImageUploader.module.css
@@ -1,4 +1,4 @@
-.imageUploader {
+/* .imageUploader {
   padding: 0px 0px 0px 0px;
   margin: 0px 0px 0px 0px;
   display: flex;
@@ -6,6 +6,13 @@
   margin-top: 20px;
   height: 715px;
   justify-content: space-between;
+} */
+
+.uploadImageViewContainer {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: 695px;
 }
 
 .dragAreaAndButtonsContainer {


### PR DESCRIPTION
## Add Image to Event
![add-image-demo](https://user-images.githubusercontent.com/58197934/145908544-87955eb4-4ae3-4673-b14f-51576db8fae8.gif)

User can now add an image to their event by clicking Upload Image
Upload image renders Add Image view.
User can add image by click navigating or by dragging and dropping.
User can remove image, or click/drag a new image to replace the current image.
Clicking Add Image returns user to Create Event view, now displaying their image.
Attempting to submit an event without a name or description renders validation warnings.

To do: add functionality to Go Back button, add validation if user tries to click Add Image with no image selected, app will (probably) crash atm
