### PR TITLE
Map events props

### DIFF
--- a/src/components/map/Map.jsx
+++ b/src/components/map/Map.jsx
@@ -37,11 +37,20 @@ const InfoBox = function InfoBox(props) {
 };
 
 /**
+ * @typedef {Object} GeoJson
+ * @property {'Feature'} type
+ * @property {Object} geometry
+ * @property {'Point'} geometry.type
+ * @property {[lng: number, lat: number]} geometry.coordinates
+ * @property {Object} properties
+
+/**
 * @param {Object} props
 * @param {React.CSSProperties} props.containerStyle
 * @param {google.maps.LatLngLiteral} props.center
-* @param {(google.maps.LatLngLiteral) => void=} props.onDrop
-* @param {GeoJSON[]} props.events
+* @param {(position: google.maps.LatLngLiteral) => void} props.onDrop
+* @param {Object} props.events
+* @param {GeoJson[]} props.events.features
 */
 const Map = function Map({ containerStyle, center, onDrop, events }) {
   const { isLoaded } = useJsApiLoader({
@@ -97,7 +106,7 @@ const Map = function Map({ containerStyle, center, onDrop, events }) {
     if (map) {
       map.data.forEach(feature => map.data.remove(feature));
       if (events) {
-        for (const feature of events.data.features) {
+        for (const feature of events.features) {
           map.data.addGeoJson(feature);
         }
       }


### PR DESCRIPTION
# Before this PR
Previously the `<Map/>` component had 2 modes, dependent on the inclusion of the optional `onDrop` property.  This was because features were loaded unconditionally from a file of sample data.

# After this PR
The `<Map/>` component now takes an additional optional property called `events`.  **Now, if you do not want to display any markers, simply leave out this property.**  This would allow event creation page to possibly include surrounding event markers if they so desire, in addition to having the `onDrop` functionality.

We also added a `useEffect` clause that will remove and then re-add markers as its parent's state changes.

## Events Property
The `events` property takes a list of "features" in GeoJSON format.  You will use a state hook in the parent component to load a list of events from the API, then pass in your events state to the `events` prop of the `Map` component.