### PR TITLE
integrate map view

### DIFF
--- a/src/components/search/results/TabViews.jsx
+++ b/src/components/search/results/TabViews.jsx
@@ -37,23 +37,20 @@ const TabViews = () => {
         </button>
       </div>
       <div className={SearchbarContext.isBarView ? styles.longtabsContent : styles.tabsContent}>
-        <div className={view === 1 ? styles.activeContent : styles.content}>
-          {view === 1 ? <EventList /> : null}
-        </div>
-        <div className={view === 2 ? styles.activeContent : styles.content}>
-          {view === 2 ? 'Map'
-            // <Map
-            //   events={{ features: SearchbarContext.results.filtered }}
-            //   containerStyle={mapStyle}
-            //   center={[-90.06911208674771, 29.954767355989652]}
-            //   />
-            : null}
-        </div>
-        <div className={view === 3 ? styles.activeContent : styles.content}>
-          {view === 3 ? <Calendar /> : null}
-        </div>
+        {view === 1 ? <div className={styles.activeContent}>
+          <EventList />
+        </div> : null}
+        {view === 2 ? <div className={styles.activeContent}>
+          <Map className='mapContainer'
+            events={{ features: SearchbarContext.results.filtered }}
+            containerStyle={mapStyle}
+            center={{ lat: 29.954767355989652, lng: -90.06911208674771 }}
+          /></div> : null}
+        {view === 3 ? <div className={styles.activeContent}>
+          <Calendar />
+        </div> : null}
       </div>
-    </div>
+    </div >
   );
 };
 

--- a/src/styles/resultList.module.css
+++ b/src/styles/resultList.module.css
@@ -39,8 +39,10 @@
   font-size: 17px;
 } */
 
-
 .tabsContent {
+  display: flex;
+  flex-direction: column;
+  justify-content: stretch;
   border: var(--buskr-lightgray) solid 1px;
   border-top: none;
   height: 330px;
@@ -48,13 +50,24 @@
   border-bottom-left-radius: 5px;
   border-bottom-right-radius: 5px;
 }
+
 .longtabsContent {
+  display: flex;
+  flex-direction: column;
+  justify-content: stretch;
   border: var(--buskr-lightgray) solid 1px;
   border-top: none;
   height: 600px;
   overflow: auto;
   border-bottom-left-radius: 5px;
   border-bottom-right-radius: 5px;
+}
+
+.content, .activeContent {
+  display: flex;
+  flex-direction: column;
+  justify-content: stretch;
+  height: 600px;
 }
 
 .eventListNoEvents {


### PR DESCRIPTION
## Story / Task

When the user clicks on the map tab, it will render a map view of the events

## What this PR does?

- it integrates the map component passing down props
- changed the tab view component so that map renders to fit the whole container

### After

![Screenshot from 2021-12-15 16-03-10](https://user-images.githubusercontent.com/82062938/146285112-6e0a07bb-a1a1-4d5c-a09f-cce55fd96bc3.png) ![Screenshot from 2021-12-15 16-02-51](https://user-images.githubusercontent.com/82062938/146285115-73ee803b-5755-45b9-86db-152feef13c65.png)


## Mentions

@apriljgranzow @mkr123 - teammate
@c4mino - helping with CSS

Thanks!
