### PR TITLE
Event page profile link

### DIFF
--- a/src/components/Event.jsx
+++ b/src/components/Event.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import Link from 'next/link';
 import axios from 'axios';
 import {
   FacebookIcon,
@@ -19,6 +20,7 @@ const Event = function Event({ event }) {
     name,
     tags,
     photos,
+    buskerId,
     buskerName,
     description,
     location: { address, locality, administrative_area_level_1 },
@@ -41,7 +43,11 @@ const Event = function Event({ event }) {
       <img className={styles.eventImage} src={photos[0]} alt={name}/>
       <div className='master-title'>{name}</div>
       <section className={styles.buskerNameContainer}>
-      <div className={styles.buskerName}>By {buskerName}</div>
+      <div className={styles.buskerName}>
+      <Link href={`/profile/${buskerId}`}>
+        { buskerName }
+      </Link>
+      </div>
         <div>
           <FacebookShareButton url={url}>
             <FacebookIcon className={styles.socialIcon}/>

--- a/src/components/profile/Profile.jsx
+++ b/src/components/profile/Profile.jsx
@@ -28,7 +28,7 @@ const Profile = ({ performer, user }) => {
           <img className ={styles.tipIcon} src='/imgs/tip-cashapp-40px.png' alt='cashapp' onClick={() => onIconClick(cashappLink)}/>
           <img className ={styles.tipIcon} src='/imgs/tip-venmo-40px.png' alt ='venmo' onClick={() => onIconClick(venmoLink)}/>
         </div>
-        {(user !== undefined && performer.id === user.id)
+        {(user !== undefined || performer.id === user.id)
         && <button className='master-button' type='text'>Add Event</button>}
         <div className='master-title'>Upcoming Events:</div>
         <div className={styles.eventCardsContainer}>


### PR DESCRIPTION
Added a link to busker's profile by clicking on their name from the full page event view.
Added a hotfix for a bug on profile page where it tries to check for `id` of a `user` that is `null`, that occurs if logged out.
No visual changes.