### PR TITLE
Return an empty object if geolocation finds no results

### DIFF
--- a/src/pages/api/search.js
+++ b/src/pages/api/search.js
@@ -3,7 +3,7 @@ import axios from 'axios';
 export default async function findCoords(req, res) {
   const { address } = req.query;
   const { GEOCODE_API_KEY } = process.env;
-  const resultfromApi = await axios.get(
+  const { data: [result] } = await axios.get(
     'https://maps.googleapis.com/maps/api/geocode/json',
     {
       params: {
@@ -12,5 +12,9 @@ export default async function findCoords(req, res) {
       },
     },
   );
-  res.send(resultfromApi.data.results[0].geometry.location);
+  if (result === undefined) {
+    res.send({});
+  } else {
+    res.send(result.geometry.location);
+  }
 }


### PR DESCRIPTION
I finally found it. This is a really simple bug fix.