### PR TITLE
Dropdown fix, Tags centered

### DIFF
--- a/src/styles/Search.module.css
+++ b/src/styles/Search.module.css
@@ -26,7 +26,7 @@
 #upperSearchBar{
   border-top-left-radius: 5px;
   border-top-right-radius: 5px;
-
+  position: relative;
 }
 .searchInput{
   position: absolute;
@@ -71,7 +71,7 @@
   flex-direction: row;
   flex-wrap: wrap;
   align-items: baseline;
-  justify-content: space-evenly;
+  justify-content: center;
   width:100%
 }
 
@@ -125,9 +125,10 @@
 .suggestions {
   margin: 0px;
   position: absolute;
+  top: 29px;
+  left: 0px;
   border: 1px solid var(--buskr-orange);
   list-style: none;
-  margin-top: 35px;
   max-height: 100px;
   overflow-y: auto;
   padding: 10px 0px 10px 25px;
@@ -191,6 +192,7 @@
   justify-content: center;
   align-items: center;
   width:335px;
+  position: relative;
 }
 
 .miniBar {


### PR DESCRIPTION
Dropdown works for both view
Default tag icons centered

![dropdown](https://user-images.githubusercontent.com/58197934/146499587-66b7dac6-5d6a-4bcc-a585-567ed1081798.gif)
